### PR TITLE
Implement OpenAI integration on upload

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 
 from .services.parser import extract_text_from_pdf
+from .services.openai_client import call_openai
 
 app = FastAPI()
 
@@ -9,4 +10,21 @@ app = FastAPI()
 @app.post("/upload")
 async def upload_pdf(file: UploadFile = File(...)):
     text = await extract_text_from_pdf(file)
-    return JSONResponse({"text": text})
+
+    if not text.strip():
+        raise HTTPException(status_code=422, detail="Leerer PDF-Text")
+
+    prompt = f"""
+    Du bist ein erfahrener Baujurist. Erstelle eine rechtssichere Mangelanzeige nach VOB/B §4(7), basierend auf folgendem Baustellenbericht:
+
+    {text}
+
+    Die Anzeige soll klar, juristisch korrekt und formal sein.
+    """
+
+    generated_text = call_openai(prompt)
+
+    return JSONResponse({
+        "text": text,
+        "generated": generated_text
+    })


### PR DESCRIPTION
## Summary
- import `call_openai` in backend
- build a prompt after extracting PDF text and send it to OpenAI
- return the generated text alongside the extracted text
- return 422 error for empty PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68457938584c83259b09f69c1d3af7ee