### PR TITLE
Add prompt builder and category for upload

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,30 +1,59 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
 from fastapi.responses import JSONResponse
 
 from .services.parser import extract_text_from_pdf
 from .services.openai_client import call_openai
 
+
+def build_prompt(category: str, content: str) -> str:
+    """Return a prompt based on the given category and content."""
+    prompts = {
+        "mangelanzeige": (
+            f"Du bist Baujurist. Erstelle eine Mangelanzeige nach VOB/B \u00a74(7) auf Basis dieses Berichts:\n\n{content}"
+        ),
+        "nachtrag": (
+            f"Formuliere einen Nachtrag gem\u00e4\u00df VOB auf Grundlage dieser Angaben:\n\n{content}"
+        ),
+        "bautagebuch": (
+            f"Erstelle einen formellen Bautagebucheintrag basierend auf folgenden Informationen:\n\n{content}"
+        ),
+        "vob_pruefen": (
+            f"Pr\u00fcfe, ob folgender Sachverhalt einen Mangel gem\u00e4\u00df VOB/B darstellt:\n\n{content}"
+        ),
+        "email_korrektur": (
+            f"Formuliere aus folgendem Rohtext eine professionelle E-Mail:\n\n{content}"
+        ),
+    }
+    return prompts.get(category, f"Verarbeite diesen Text:\n\n{content}")
+
 app = FastAPI()
 
 
 @app.post("/upload")
-async def upload_pdf(file: UploadFile = File(...)):
+async def upload_pdf(
+    file: UploadFile = File(...),
+    category: str = Form("mangelanzeige"),
+):
     text = await extract_text_from_pdf(file)
 
     if not text.strip():
         raise HTTPException(status_code=422, detail="Leerer PDF-Text")
 
-    prompt = f"""
-    Du bist ein erfahrener Baujurist. Erstelle eine rechtssichere Mangelanzeige nach VOB/B §4(7), basierend auf folgendem Baustellenbericht:
+    valid_categories = {
+        "mangelanzeige",
+        "nachtrag",
+        "bautagebuch",
+        "vob_pruefen",
+        "email_korrektur",
+    }
 
-    {text}
+    if category and category not in valid_categories:
+        raise HTTPException(status_code=400, detail="Ungültige Kategorie")
 
-    Die Anzeige soll klar, juristisch korrekt und formal sein.
-    """
-
+    prompt = build_prompt(category, text)
     generated_text = call_openai(prompt)
 
     return JSONResponse({
         "text": text,
-        "generated": generated_text
+        "generated": generated_text,
     })


### PR DESCRIPTION
## Summary
- extend `/upload` endpoint to accept `category` using `Form`
- build prompts based on category via `build_prompt`
- validate category and generate text via OpenAI

## Testing
- `python -m py_compile backend/main.py backend/services/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68457ae206288325a3bc77653d4205f3