### PR TITLE
Add React frontend with Tailwind CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Baucoach Frontend</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect } from 'react'
+
+function App() {
+  const [category, setCategory] = useState('mangelanzeige')
+  const [file, setFile] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [generated, setGenerated] = useState('')
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    if (!error) return
+    const t = setTimeout(() => setError(''), 5000)
+    return () => clearTimeout(t)
+  }, [error])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!file) {
+      setError('Bitte eine PDF-Datei hochladen.')
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('category', category)
+
+    setLoading(true)
+    setError('')
+    setGenerated('')
+    setText('')
+
+    try {
+      const res = await fetch('http://localhost:8000/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!res.ok) {
+        const msg = await res.text()
+        throw new Error(msg || 'Upload fehlgeschlagen')
+      }
+
+      const data = await res.json()
+      setText(data.text)
+      setGenerated(data.generated)
+    } catch (err) {
+      setError('Fehler: ' + err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Baucoach Upload</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <select
+          className="border rounded p-2"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="mangelanzeige">mangelanzeige</option>
+          <option value="nachtrag">nachtrag</option>
+          <option value="bautagebuch">bautagebuch</option>
+          <option value="vob_pruefen">vob_pruefen</option>
+          <option value="email_korrektur">email_korrektur</option>
+        </select>
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="block"
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+          disabled={loading}
+        >
+          Absenden
+        </button>
+      </form>
+      {loading && <p className="mt-4">Verarbeite...</p>}
+      {error && <p className="mt-4 text-red-500">{error}</p>}
+      {generated && (
+        <div className="mt-4">
+          <h2 className="font-semibold">GPT-generierter Text</h2>
+          <pre className="whitespace-pre-wrap">{generated}</pre>
+        </div>
+      )}
+      {text && (
+        <div className="mt-4">
+          <h2 className="font-semibold">Extrahierter Rohtext</h2>
+          <pre className="whitespace-pre-wrap">{text}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "baucoach-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./frontend/index.html', './frontend/src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: 'frontend',
+})


### PR DESCRIPTION
## Summary
- set up Vite React project in `frontend`
- add Tailwind CSS configuration
- implement `App.jsx` with upload form and result display
- include main entry, HTML template and config files
- add `.gitignore` to exclude node artifacts

## Testing
- `node --version`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_6845c01213448325813fb6e28a9afb95