### PR TITLE
Update OpenAI client to v1 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cp .env.example .env
 2. Install the required packages:
 
 ```
-pip install fastapi uvicorn pdfplumber python-dotenv openai
+pip install fastapi uvicorn pdfplumber python-dotenv openai>=1.0.0
 ```
 
 ## Running the Backend

--- a/backend/services/openai_client.py
+++ b/backend/services/openai_client.py
@@ -1,18 +1,18 @@
 import os
 
 from dotenv import load_dotenv
-import openai
+from openai import OpenAI
 
 load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-openai.api_key = OPENAI_API_KEY
+client = OpenAI(api_key=OPENAI_API_KEY)
 
 
 def call_openai(prompt: str) -> str:
     """Call OpenAI API with the given prompt and return the response text."""
-    response = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
     )
-    return response["choices"][0]["message"]["content"]
+    return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- update the OpenAI integration to use `OpenAI` client object
- require OpenAI SDK 1.0+ in documentation

## Testing
- `python -m py_compile backend/services/openai_client.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_b_6845e80b83608325a4c3f6c1f484eaed