### PR TITLE
Add venv activation reminder in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,3 +11,4 @@ if [ ! -f .env ]; then
 fi
 
 alembic upgrade head
+echo "Setup complete. Run \"source .venv/bin/activate\" to activate the virtual environment."


### PR DESCRIPTION
## Summary
- remind the user to activate the virtual environment after running `setup.sh`

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_b_6847e06e7ba48325b9c97685dbfec952